### PR TITLE
Limit the number of scores in the feed #21

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.includes(:user).order(played_at: :desc, id: :desc).limit(25)
+      scores = Score.all.order(played_at: :desc, id: :desc).limit(25)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.includes(:user).order(played_at: :desc, id: :desc).limit(25)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -28,9 +28,8 @@ describe Api::ScoresController, type: :request do
     end
 
     it 'should limit number of scores to 25' do
-
-      27.times do|i|
-        create(:score, user: @user1, total_score: i, played_at: '2021-05-20')
+      27.times do |i|
+        create(:score, user: @user1, total_score: 66 + i, played_at: '2021-05-20')
       end
 
       get api_feed_path

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -26,6 +26,21 @@ describe Api::ScoresController, type: :request do
       expect(scores[1]['total_score']).to eq 68
       expect(scores[2]['total_score']).to eq 79
     end
+
+    it 'should limit number of scores to 25' do
+
+      27.times do|i|
+        create(:score, user: @user1, total_score: i, played_at: '2021-05-20')
+      end
+
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+      response_hash = JSON.parse(response.body)
+      scores = response_hash['scores']
+
+      expect(scores.size).to eq 25
+    end
   end
 
   describe 'POST create' do


### PR DESCRIPTION
Fixes:[ Limit the number of scores in the feed #21](https://github.com/AACraiu/golfr_backend/issues/21)

**Changes**

Added a limit to 25 for user scores and added an integration test for this restriction
In order to demonstrate changes I increased the scores generation loop count in seeds.rb to have more than 25 scores in the feed (this change is not pushed)

**Before**
**On UI**: Note the scroll bar reduced length -> more than 25 posts
![image](https://user-images.githubusercontent.com/118548930/208399428-9a4fcc68-b6cd-4adf-aeb3-47a4e54dd6fc.png)

**In postman:** A list element takes 7 rows and having 550 total rows => more than 25 posts
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/118548930/208399484-6ff18df0-e170-4621-8784-91e67214eea5.png">


**After**

**On UI:** Scrollbar length reduced significantly
![image](https://user-images.githubusercontent.com/118548930/208401147-84c0609c-becf-4b5f-a244-1adccf5faba3.png)

**In postman:** 175 lines / 7 = 25
<img width="1284" alt="image" src="https://user-images.githubusercontent.com/118548930/208401343-54855eb4-4710-4e6b-9ff2-f5aea9933680.png">

